### PR TITLE
Add iOS backend support and integrate apple-utils

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,10 @@ web-sys = { version = "0.3.46", features = [
 ] }
 wasm-bindgen-futures = "0.4.19"
 
+[target.'cfg(target_os = "ios")'.dependencies]
+apple-utils = { git = "https://github.com/maun/apple-utils" }
+pollster = { version = "0.4" }
+
 [[example]]
 name = "simple"
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ web-sys = { version = "0.3.46", features = [
 wasm-bindgen-futures = "0.4.19"
 
 [target.'cfg(target_os = "ios")'.dependencies]
-apple-utils = { git = "https://github.com/maun/apple-utils" }
+apple-utils = "0.1.0"
 pollster = { version = "0.4" }
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ wasm-bindgen-futures = "0.4.19"
 [target.'cfg(target_os = "ios")'.dependencies]
 apple-utils = "0.1.0"
 pollster = { version = "0.4" }
+dispatch2 = "0.3.0"
 
 [[example]]
 name = "simple"

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -30,6 +30,8 @@ mod linux;
 mod gtk3;
 #[cfg(target_os = "macos")]
 mod macos;
+#[cfg(target_os = "ios")]
+mod ios;
 #[cfg(target_arch = "wasm32")]
 mod wasm;
 #[cfg(target_os = "windows")]

--- a/src/backend/ios.rs
+++ b/src/backend/ios.rs
@@ -1,0 +1,3 @@
+mod file_dialog;
+mod message_dialog;
+

--- a/src/backend/ios/file_dialog.rs
+++ b/src/backend/ios/file_dialog.rs
@@ -3,6 +3,10 @@ use crate::{FileDialog, FileHandle};
 
 #[cfg(not(target_arch = "wasm32"))]
 use std::path::PathBuf;
+#[cfg(target_os = "ios")]
+use apple_utils::file_type::FileType;
+#[cfg(target_os = "ios")]
+use apple_utils::ios::FilePicker;
 
 //
 // File Picker (sync)
@@ -13,11 +17,29 @@ use crate::backend::FilePickerDialogImpl;
 #[cfg(not(target_arch = "wasm32"))]
 impl FilePickerDialogImpl for FileDialog {
     fn pick_file(self) -> Option<PathBuf> {
-        None
+        #[cfg(target_os = "ios")]
+        {
+            let picker = build_picker_from_file_dialog(&self, false);
+            let mut res = pollster::block_on(picker.open());
+            res.into_iter().next()
+        }
+        #[cfg(not(target_os = "ios"))]
+        {
+            None
+        }
     }
 
     fn pick_files(self) -> Option<Vec<PathBuf>> {
-        None
+        #[cfg(target_os = "ios")]
+        {
+            let picker = build_picker_from_file_dialog(&self, true);
+            let res = pollster::block_on(picker.open());
+            if res.is_empty() { None } else { Some(res) }
+        }
+        #[cfg(not(target_os = "ios"))]
+        {
+            None
+        }
     }
 }
 
@@ -28,11 +50,37 @@ impl FilePickerDialogImpl for FileDialog {
 use crate::backend::AsyncFilePickerDialogImpl;
 impl AsyncFilePickerDialogImpl for FileDialog {
     fn pick_file_async(self) -> DialogFutureType<Option<FileHandle>> {
-        Box::pin(async { None })
+        Box::pin(async move {
+            #[cfg(target_os = "ios")]
+            {
+                let picker = build_picker_from_file_dialog(&self, false);
+                let mut paths = picker.open().await;
+                paths.into_iter().next().map(FileHandle::wrap)
+            }
+            #[cfg(not(target_os = "ios"))]
+            {
+                None
+            }
+        })
     }
 
     fn pick_files_async(self) -> DialogFutureType<Option<Vec<FileHandle>>> {
-        Box::pin(async { None })
+        Box::pin(async move {
+            #[cfg(target_os = "ios")]
+            {
+                let picker = build_picker_from_file_dialog(&self, true);
+                let paths = picker.open().await;
+                if paths.is_empty() {
+                    None
+                } else {
+                    Some(paths.into_iter().map(FileHandle::wrap).collect())
+                }
+            }
+            #[cfg(not(target_os = "ios"))]
+            {
+                None
+            }
+        })
     }
 }
 
@@ -45,11 +93,29 @@ use crate::backend::FolderPickerDialogImpl;
 #[cfg(not(target_arch = "wasm32"))]
 impl FolderPickerDialogImpl for FileDialog {
     fn pick_folder(self) -> Option<PathBuf> {
-        None
+        #[cfg(target_os = "ios")]
+        {
+            let picker = build_folder_picker_from_file_dialog(&self, false);
+            let mut res = pollster::block_on(picker.open());
+            res.into_iter().next()
+        }
+        #[cfg(not(target_os = "ios"))]
+        {
+            None
+        }
     }
 
     fn pick_folders(self) -> Option<Vec<PathBuf>> {
-        None
+        #[cfg(target_os = "ios")]
+        {
+            let picker = build_folder_picker_from_file_dialog(&self, true);
+            let res = pollster::block_on(picker.open());
+            if res.is_empty() { None } else { Some(res) }
+        }
+        #[cfg(not(target_os = "ios"))]
+        {
+            None
+        }
     }
 }
 
@@ -62,11 +128,37 @@ use crate::backend::AsyncFolderPickerDialogImpl;
 #[cfg(not(target_arch = "wasm32"))]
 impl AsyncFolderPickerDialogImpl for FileDialog {
     fn pick_folder_async(self) -> DialogFutureType<Option<FileHandle>> {
-        Box::pin(async { None })
+        Box::pin(async move {
+            #[cfg(target_os = "ios")]
+            {
+                let picker = build_folder_picker_from_file_dialog(&self, false);
+                let mut paths = picker.open().await;
+                paths.into_iter().next().map(FileHandle::wrap)
+            }
+            #[cfg(not(target_os = "ios"))]
+            {
+                None
+            }
+        })
     }
 
     fn pick_folders_async(self) -> DialogFutureType<Option<Vec<FileHandle>>> {
-        Box::pin(async { None })
+        Box::pin(async move {
+            #[cfg(target_os = "ios")]
+            {
+                let picker = build_folder_picker_from_file_dialog(&self, true);
+                let paths = picker.open().await;
+                if paths.is_empty() {
+                    None
+                } else {
+                    Some(paths.into_iter().map(FileHandle::wrap).collect())
+                }
+            }
+            #[cfg(not(target_os = "ios"))]
+            {
+                None
+            }
+        })
     }
 }
 
@@ -90,7 +182,48 @@ impl FileSaveDialogImpl for FileDialog {
 use crate::backend::AsyncFileSaveDialogImpl;
 impl AsyncFileSaveDialogImpl for FileDialog {
     fn save_file_async(self) -> DialogFutureType<Option<FileHandle>> {
-        Box::pin(async { None })
+        Box::pin(async move { None })
+    }
+}
+
+#[cfg(target_os = "ios")]
+fn build_picker_from_file_dialog(fd: &FileDialog, multiple: bool) -> FilePicker {
+    let mut filters: Vec<FileType> = Vec::new();
+    if fd.filters.is_empty() {
+        filters.push(FileType::Any);
+    } else {
+        for f in &fd.filters {
+            if f.extensions.is_empty() {
+                filters.push(FileType::Any);
+            } else {
+                for ext in &f.extensions {
+                    filters.push(FileType::Extension(ext.clone()));
+                }
+            }
+        }
+    }
+
+    FilePicker {
+        present_animated: true,
+        filters,
+        multiple_selection: multiple,
+        show_file_extensions: false,
+        copy_files: false,
+        directory_path: fd.starting_directory.clone(),
+    }
+}
+
+#[cfg(target_os = "ios")]
+fn build_folder_picker_from_file_dialog(fd: &FileDialog, multiple: bool) -> FilePicker {
+    let filters = vec![FileType::UniformTypeIdentifier("public.folder".to_string())];
+
+    FilePicker {
+        present_animated: true,
+        filters,
+        multiple_selection: multiple,
+        show_file_extensions: false,
+        copy_files: false,
+        directory_path: fd.starting_directory.clone(),
     }
 }
 

--- a/src/backend/ios/file_dialog.rs
+++ b/src/backend/ios/file_dialog.rs
@@ -1,0 +1,96 @@
+use crate::backend::DialogFutureType;
+use crate::{FileDialog, FileHandle};
+
+#[cfg(not(target_arch = "wasm32"))]
+use std::path::PathBuf;
+
+//
+// File Picker (sync)
+//
+
+#[cfg(not(target_arch = "wasm32"))]
+use crate::backend::FilePickerDialogImpl;
+#[cfg(not(target_arch = "wasm32"))]
+impl FilePickerDialogImpl for FileDialog {
+    fn pick_file(self) -> Option<PathBuf> {
+        None
+    }
+
+    fn pick_files(self) -> Option<Vec<PathBuf>> {
+        None
+    }
+}
+
+//
+// File Picker (async)
+//
+
+use crate::backend::AsyncFilePickerDialogImpl;
+impl AsyncFilePickerDialogImpl for FileDialog {
+    fn pick_file_async(self) -> DialogFutureType<Option<FileHandle>> {
+        Box::pin(async { None })
+    }
+
+    fn pick_files_async(self) -> DialogFutureType<Option<Vec<FileHandle>>> {
+        Box::pin(async { None })
+    }
+}
+
+//
+// Folder Picker (sync)
+//
+
+#[cfg(not(target_arch = "wasm32"))]
+use crate::backend::FolderPickerDialogImpl;
+#[cfg(not(target_arch = "wasm32"))]
+impl FolderPickerDialogImpl for FileDialog {
+    fn pick_folder(self) -> Option<PathBuf> {
+        None
+    }
+
+    fn pick_folders(self) -> Option<Vec<PathBuf>> {
+        None
+    }
+}
+
+//
+// Folder Picker (async)
+//
+
+#[cfg(not(target_arch = "wasm32"))]
+use crate::backend::AsyncFolderPickerDialogImpl;
+#[cfg(not(target_arch = "wasm32"))]
+impl AsyncFolderPickerDialogImpl for FileDialog {
+    fn pick_folder_async(self) -> DialogFutureType<Option<FileHandle>> {
+        Box::pin(async { None })
+    }
+
+    fn pick_folders_async(self) -> DialogFutureType<Option<Vec<FileHandle>>> {
+        Box::pin(async { None })
+    }
+}
+
+//
+// File Save (sync)
+//
+
+#[cfg(not(target_arch = "wasm32"))]
+use crate::backend::FileSaveDialogImpl;
+#[cfg(not(target_arch = "wasm32"))]
+impl FileSaveDialogImpl for FileDialog {
+    fn save_file(self) -> Option<PathBuf> {
+        None
+    }
+}
+
+//
+// File Save (async)
+//
+
+use crate::backend::AsyncFileSaveDialogImpl;
+impl AsyncFileSaveDialogImpl for FileDialog {
+    fn save_file_async(self) -> DialogFutureType<Option<FileHandle>> {
+        Box::pin(async { None })
+    }
+}
+

--- a/src/backend/ios/message_dialog.rs
+++ b/src/backend/ios/message_dialog.rs
@@ -1,0 +1,17 @@
+use crate::backend::DialogFutureType;
+use crate::message_dialog::{MessageDialog, MessageDialogResult};
+
+use crate::backend::{AsyncMessageDialogImpl, MessageDialogImpl};
+
+impl MessageDialogImpl for MessageDialog {
+    fn show(self) -> MessageDialogResult {
+        MessageDialogResult::Cancel
+    }
+}
+
+impl AsyncMessageDialogImpl for MessageDialog {
+    fn show_async(self) -> DialogFutureType<MessageDialogResult> {
+        Box::pin(async { MessageDialogResult::Cancel })
+    }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 //!   * Windows
 //!   * macOS
 //!   * Linux & BSDs (GTK3 or XDG Desktop Portal)
+//!   * iOS (via apple-utils; async preferred)
 //!   * WASM32 (async only)
 //!
 //! # Examples
@@ -102,16 +103,16 @@
 //! | ------------- |
 //! | 🚧             |
 //!
-//! | Feature      | Linux | Windows | MacOS     | Wasm32 |
-//! | ------------ | ----- | ------- | --------- | ------ |
-//! | SingleFile   | ✔     | ✔       | ✔         | ✔      |
-//! | MultipleFile | ✔     | ✔       | ✔         | ✔      |
-//! | PickFolder   | ✔     | ✔       | ✔         | ✖      |
-//! | SaveFile     | ✔     | ✔       | ✔         | ✖      |
-//! |              |       |         |           |        |
-//! | Filters      | ✔ ([GTK only](https://github.com/PolyMeilex/rfd/issues/42)) | ✔ | ✔ | ✔ |
-//! | StartingPath | ✔     | ✔       | ✔         | ✖      |
-//! | Async        | ✔     | ✔       | ✔         | ✔      |
+//! | Feature      | Linux | Windows | MacOS     | iOS | Wasm32 |
+//! | ------------ | ----- | ------- | --------- | --- | ------ |
+//! | SingleFile   | ✔     | ✔       | ✔         | ✔  | ✔      |
+//! | MultipleFile | ✔     | ✔       | ✔         | ✔  | ✔      |
+//! | PickFolder   | ✔     | ✔       | ✔         | ✔  | ✖      |
+//! | SaveFile     | ✔     | ✔       | ✔         | ✖  | ✖      |
+//! |              |       |         |           |    |        |
+//! | Filters      | ✔ ([GTK only](https://github.com/PolyMeilex/rfd/issues/42)) | ✔ | ✔ | ✔ | ✔ |
+//! | StartingPath | ✔     | ✔       | ✔         | ✔  | ✖      |
+//! | Async        | ✔     | ✔       | ✔         | ✔  | ✔      |
 //!
 //! # rfd-extras
 //!


### PR DESCRIPTION
Add initial iOS backend module with placeholder trait implementations.

This PR lays the groundwork for iOS support, creating the necessary module structure and stubbing out the dialog trait implementations to ensure compilation.

---
<a href="https://cursor.com/background-agent?bcId=bc-5225704d-ac23-4498-8b8e-560ada982601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5225704d-ac23-4498-8b8e-560ada982601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

